### PR TITLE
Vercel Deploy Fix #2

### DIFF
--- a/services/RequestQueue.ts
+++ b/services/RequestQueue.ts
@@ -19,7 +19,7 @@ function createRequestQueue(maxRequestsPerSecond: number) {
         console.error("Error en la solicitud:", error);
       } finally {
         activeRequests--;
-        setTimeout(processQueue, 3000); // espera 5 segundos antes de procesar la siguiente solicitud
+        setTimeout(processQueue, 1000); // espera 2 segundos antes de procesar la siguiente solicitud
       }
     }
   }

--- a/services/fetchData.ts
+++ b/services/fetchData.ts
@@ -28,7 +28,7 @@ export default async function fetchData<T>(url: string): Promise<T> {
             reject(error); // Rechaza la promesa con el error 404
             break; // Rompe el bucle en caso de un error 404
           }
-          await delay(3000); // Espera antes de reintentar
+          await delay(1000); // Espera antes de reintentar
         }
       }
     });


### PR DESCRIPTION
reducido a 1 segundo la espera entre retrys del fetch (cuando hay error 429) y entre queues cuando hay muchas solicitudes a la vez, para agilizar los fetchs y evitar el error de vercel Connection Closed